### PR TITLE
Added `upperBoundIsInclusive` to `RangeWithUpperBound`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ In Swift's standard library, all the range types conform to `RangeExpression`. H
 
 This package adds more protocols. These, for accessing members of a range generically:
 
-- `RangeProtocol`: A protocol to which all ranges, even `NSRange`, conform
+- `RangeProtocol`: A protocol to which all ranges, even `NSRange`, conform. Also includes info on whether that upper bound is inclusive.
 - `RangeWithLowerBound`: Any range which has a lower bound, such as `a...`, `a..<b`, and `a...b`
-- `RangeWithUpperBound`: Any range which has an upper bound, such as `..<b`, `...b`, `a..<b`, and `a...b`. Also includes info on whether that upper bound is inclusive.
+- `RangeWithUpperBound`: Any range which has an upper bound, such as `..<b`, `...b`, `a..<b`, and `a...b`
 - `RangeWithLowerAndUpperBound`: Any range which has both a lower and an upper bound, such as `a..<b` and `a...b`
 
 And these for creating ranges generically:

--- a/Sources/RangeTools/Default conformances.swift
+++ b/Sources/RangeTools/Default conformances.swift
@@ -23,7 +23,9 @@ extension ClosedRange: RangeWithLowerAndUpperBound {
 
 
 
-extension PartialRangeFrom: RangeWithLowerBound {}
+extension PartialRangeFrom: RangeWithLowerBound {
+    public static var upperBoundIsInclusive: Bool { true }
+}
 
 
 

--- a/Sources/RangeTools/RangeProtocol.swift
+++ b/Sources/RangeTools/RangeProtocol.swift
@@ -20,6 +20,10 @@ public protocol RangeProtocol {
     
     
     
+    /// `true` iff the upper bound of this protocol includes the element at its index, like `a...`, `...b`, and `a...b`. `false` indicates that the upper bound does not include that element, like `..<b` and `a..<b`.
+    static var upperBoundIsInclusive: Bool { get }
+    
+    
     /// Determines whether this range contains the given element
     ///
     /// - Parameter element: The element you want to see if this range contains
@@ -58,9 +62,6 @@ public protocol RangeWithUpperBound: RangeProtocol {
     
     /// The range's upper bound
     var upperBound: Bound { get }
-    
-    /// `true` iff the upper bound of this protocol includes the element at its index, like `...b` and `a...b`. `false` indicates that the upper bound does not include that element, like `..<b` and `a..<b`.
-    static var upperBoundIsInclusive: Bool { get }
 }
 
 

--- a/Tests/RangeToolsTests/RangeToolsTests.swift
+++ b/Tests/RangeToolsTests/RangeToolsTests.swift
@@ -55,6 +55,7 @@ final class RangeToolsTests: XCTestCase {
     
     
     func test_upperBoundIsInclusive() {
+        XCTAssertTrue (type(of: 5... ).upperBoundIsInclusive)
         XCTAssertFalse(type(of:  ..<7).upperBoundIsInclusive)
         XCTAssertTrue (type(of:  ...7).upperBoundIsInclusive)
         XCTAssertFalse(type(of: 5..<7).upperBoundIsInclusive)


### PR DESCRIPTION
Even when an upper bound isn't explicitly specified, it's still good to acknowledge whether it's inclusive, so we know that things like `myArray = [0,1,2]` can return `[]` validly when accessed like `myArray[3...]`.

We might imagine that, given a hypothetical `a..<` range, `myArray[3..<]` would not validly return `[]`:

```swift
let myArray = [0, 1, 2]
myArray[0...] == [0, 1, 2]
myArray[1...] == [   1, 2]
myArray[2...] == [      2]
myArray[3...] == [       ]

myArray[0..<] == [0, 1]
myArray[1..<] == [   1]
myArray[2..<] == [    ]
myArray[3..<] == invalid!
```

So, even if the range doesn't specify its upper bound, we can still gain useful knowledge by understanding whether the upper end of it is inclusive
